### PR TITLE
Remove superfluous argument for mvaddstr

### DIFF
--- a/ncurses.rkt
+++ b/ncurses.rkt
@@ -41,7 +41,7 @@
 (define-curses addnstr (_fun _string _int -> _int))
 (define-curses waddstr (_fun _WINDOW-pointer _string -> _int))
 (define-curses waddnstr (_fun _WINDOW-pointer _string _int -> _int))
-(define-curses mvaddstr (_fun _int _int _string _int -> _int))
+(define-curses mvaddstr (_fun _int _int _string -> _int))
 (define-curses mvaddnstr (_fun _int _int _string _int -> _int))
 (define-curses mvwaddstr (_fun _WINDOW-pointer _int _int _string -> _int))
 (define-curses mvwaddnstr (_fun _WINDOW-pointer _int _int _string _int -> _int))


### PR DESCRIPTION
Hi,
got an error when trying to run this, PR provides a simple fix.
Probably just a copy&paste error from `mvaddnstr`.
Thanks for putting this together, Frank
